### PR TITLE
Adjust Order of Elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,7 @@ BitPay provides powerful integrations for businesses to add bitcoin as a payment
 
 Over 30,000 businesses and organizations including WordPress, Shopify, TigerDirect, and Virgin Galactic trust BitPay to enable bitcoin payments.
 
-##Logo
-###Primary logo
-This is the best logo for all applications. It is the [white logo](bitpay-logo-primary.png) on the BitPay Blue background.
-![BitPay Logo](bitpay-logo-full.png)
-###Logo inverted
-![BitPay Logo Inverse](bitpay-logo-inverse.png)
-
-##BitPay
-
+## Name
 BitPay is written with the `B` and `P` capitalized to distinguish BitPay (our company) from Bitcoin (the currency). In code, `bitpay` is all lowercase.
 
 - ✓ **BitPay**
@@ -23,22 +15,29 @@ BitPay is written with the `B` and `P` capitalized to distinguish BitPay (our co
 - × *bit-pay*
 - × *bit pay*
 
-##BitPay Blue
+## Logo
+### Primary logo
+This is the best logo for all applications. It is the [white logo](bitpay-logo-primary.png) on the BitPay Blue background.
+![BitPay Logo](bitpay-logo-full.png)
+### Logo inverted
+![BitPay Logo Inverse](bitpay-logo-inverse.png)
+
+## BitPay Blue
 
 The BitPay Blue is PMS 295. Please use official Pantone Matching System swatches where available.
 
-###Close Matches
+### Close Matches
 
-####sRGB
+#### sRGB
 
 | Red | Green | Blue |
 |:---:|:-----:|:----:|
 |  0  |   40  |  85  |
 
-#####Hex
+##### Hex
 `#002855`
 
-####Bridge CMYK
+#### Bridge CMYK
 
 | Cyan | Magenta | Yellow | Key (Black) |
 |:----:|:-------:|:------:|:-----------:|


### PR DESCRIPTION
This moves the "name" section (renamed from "BitPay") above the images for the logo, as this is a shorter section and deserves higher attention as it is the most common violation of our brand guidelines.
